### PR TITLE
Add ipaex-mincho

### DIFF
--- a/files/ipaex-mincho.json
+++ b/files/ipaex-mincho.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://schemas.openfonts.jp/package/v01/schema.json",
+  "name": "IPAexMincho",
+  "id": "ipaex-mincho",
+  "version": "003.01",
+  "characters": [
+    "Alphabets",
+    "Hiragana",
+    "Katakana",
+    "Kanji"
+  ],
+  "website": "https://ipafont.ipa.go.jp/",
+  "fallback": "IPAexMincho",
+  "copyrights": [
+    "Copyright (c) 2015 IPA 独立行政法人情報処理推進機構 Information-technology Promotion Agency, Japan."
+  ],
+  "categories": [
+    "Mincho"
+  ],
+  "owners": [
+    "IPA 独立行政法人情報処理推進機構"
+  ],
+  "files": [
+    {
+      "from": "https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip"
+    }
+  ],
+  "license": {
+    "id": "IPA"
+  }
+}

--- a/files/ipaex-mincho.json
+++ b/files/ipaex-mincho.json
@@ -22,7 +22,10 @@
   ],
   "files": [
     {
-      "from": "https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip"
+      "from": "https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip",
+      "fonts": {
+        "normal": "ipaexm.ttf"
+      }
     }
   ],
   "license": {


### PR DESCRIPTION

|フォント名|IPAexMincho|
|:--|:--|
|フォントID|ipaex-mincho|
|バージョン|003.01|
|カテゴリ|Mincho|
|文字種|Alphabets, Hiragana, Katakana, Kanji|
|製作者|IPA 独立行政法人情報処理推進機構|
|Webサイト|https://ipafont.ipa.go.jp/|
|フォントファイル URL|https://oscdl.ipa.go.jp/IPAexfont/ipaexm00301.zip|
|ライセンス|IPA|
|コピーライト|Copyright (c) 2015 IPA 独立行政法人情報処理推進機構 Information-technology Promotion Agency, Japan.|
|登録状況の通知|@3846masa|

**:warning: マージ前に必ずライセンスの確認とフォントファイル名の追加を行ってください**
  